### PR TITLE
Add a basic spellchecking functionality to information page

### DIFF
--- a/docassemble/ALLinter/data/questions/interview_wide_linter.yml
+++ b/docassemble/ALLinter/data/questions/interview_wide_linter.yml
@@ -57,6 +57,9 @@ code: |
 code: |
   warnings = text_violations(interview_texts_no_mako)
 ---
+code: |
+  misspelled = get_misspelled_words(paragraph)
+---
 event: results
 question: |
   Interview Suggestions
@@ -66,6 +69,16 @@ subquestion: |
   % for key, val in interview_scores.items():
   * ${ key } : ${ val }
   % endfor
+  
+  % if misspelled:
+  ### Misspelled words
+  
+  It looks like these words are misspelled:
+  
+  % for misspelled_word in misspelled:
+  * ${ misspelled_word }
+  % endfor  
+  % endif
   
   % if headings_warnings or warnings:
   ### Warnings:
@@ -83,6 +96,8 @@ subquestion: |
   % endfor
   
   % endif
+  
+  
 help:
   label: |
     Text used

--- a/docassemble/ALLinter/linter.py
+++ b/docassemble/ALLinter/linter.py
@@ -6,7 +6,33 @@ import mako.runtime
 import mako.exceptions
 import docassemble.webapp.screenreader
 import docassemble.base.filter
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Mapping, Set, Union
+from spellchecker import SpellChecker
+
+__all__ = [
+    "get_misspelled_words",
+    "get_corrections",
+    "load_interview",
+    "remove_mako",
+    "get_all_headings",
+    "get_heading_width",
+    "headings_violations",
+    "text_violations",
+    "get_all_text",
+]
+
+def get_misspelled_words(text:str, language:str="en")->Set[str]:
+    spell = SpellChecker(language=language)
+    return spell.unknown(re.findall(r'\w+', text))
+    
+def get_corrections(misspelled:Union[Set[str], List[str]], language:str="en")->Mapping[str, Set[str]]:
+    spell = SpellChecker(language=language)
+    return [
+        {
+            misspelled_word: spell.corrections(misspelled_word)
+        }
+       for misspelled_word in misspelled
+    ]
 
 mega_list = ('default', 'input type', 'using', 'keep for training',
       'validation messages', 'validate', 'rows', 'maximum image size',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='docassemble.ALLinter',
       url='https://docassemble.org',
       packages=find_packages(),
       namespace_packages=['docassemble'],
-      install_requires=['Mako>=1.1.4', 'ruamel.yaml>=0.17.4', 'plumbum>=1.7.2',  'textstat>=0.7.0'],
+      install_requires=['Mako>=1.1.4', 'pyspellchecker>=0.6.3', 'ruamel.yaml>=0.17.4', 'plumbum>=1.7.2',  'textstat>=0.7.0'],
       zip_safe=False,
       package_data=find_package_data(where='docassemble/ALLinter/', package='docassemble.ALLinter'),
      )


### PR DESCRIPTION
Fix #1 

This feature is pretty basic but it works similarly to the other functionality for now.

A major limit is that the spelling errors aren't displayed with any context, but that's the same for the remaining warnings and errors. I assume we will eventually want to display errors and warnings on a per-block basis so that the author gets more context.

We may want to consider adding our own library of terms that will be incorrectly flagged, as the pyspellchecker dataset is drawn from closed captioning and may not capture some relatively common legal language.